### PR TITLE
Speed up generate.js

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -35,11 +35,11 @@ function strToRe(str) {
 		set.addRange.apply(set, range);
 	});
 
-	return set.toRegExp();
+	return set.toString();
 }
 
 var ret = Object.keys(src).map(function (key) {
-	return 'exports.' + key + ' = ' + strToRe(src[key]) + ';';
+	return 'exports.' + key + ' = /' + strToRe(src[key]) + '/;';
 }).join('\n\n');
 
 fs.writeFileSync('index.js', ret);


### PR DESCRIPTION
`regenerate#toRegExp` calls `regenerate#toString` and then just wraps it in `RegExp`. `generate.js` used to take the result of `toRegExp` and then coerce it back into a string. This small change skips these two redundant steps by just using the result of `toString` directly.
